### PR TITLE
move validation after inflate to catch array/objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "adminjs-graphql",
-   "version": "2.4.0",
+   "version": "2.4.1",
    "description": "adminjs GraphQL adapter",
    "keywords": [
       "admin-bro",

--- a/src/GraphQLResource.ts
+++ b/src/GraphQLResource.ts
@@ -219,8 +219,6 @@ export class GraphQLResourceAdapter extends BaseResource {
                 });
             }
         }, {} as ParamsType);
-
-        this.validateParams(converted);
         return converted;
     }
 
@@ -266,6 +264,7 @@ export class GraphQLResourceAdapter extends BaseResource {
     async create(params: ParamsType): Promise<ParamsType> {
         try {
             const inflated = inflateParams(this.convertParams(params));
+            this.validateParams(inflated);
             const mapping = this.rawResource.create?.(inflated);
             if (!mapping) {
                 throw new ForbiddenError("Resource is not editable");
@@ -279,6 +278,7 @@ export class GraphQLResourceAdapter extends BaseResource {
     async update(id: string, params: ParamsType): Promise<ParamsType> {
         try {
             const inflated = inflateParams(this.convertParams(params));
+            this.validateParams(inflated);
             const mapping = this.rawResource.update?.(id, inflated);
             if (!mapping) {
                 throw new ForbiddenError("Resource is not editable");
@@ -417,7 +417,7 @@ function inflateParams(
             object[steps[0]] = params[path];
         }
     }
-
+    
     return record;
 }
 


### PR DESCRIPTION
During a create, params are flattened before reaching the adaptor and the validation can not handle this. 

E.g
names.0.name

For update params will contain the array and the flattened 

E.g
names[{name:"xy"}]

As inflateParams is "unflattering" already I moved validation to be done after instead of prior